### PR TITLE
Bump to IceCC 1.2

### DIFF
--- a/org.webkit.CommonModules.json
+++ b/org.webkit.CommonModules.json
@@ -538,7 +538,8 @@
             {
                 "type": "git",
                 "url": "https://github.com/icecc/icecream",
-                "branch": "1.1"
+                "tag": "1.2",
+                "commit": "e3d10a32bc6c046d8f3d1182e75c659d4b28ed49"
             }
         ],
         "config-opts": [


### PR DESCRIPTION
Update IceCC/Icecream to version 1.2, which is the same version currently shipped with Debian stable (Buster). This bump is needed because IceCC 1.1 does not seem to interoperate with the scheduler from newer versions and it is expected that people who run IceCC will install IceCC in their build farm from distribution packages.

While at it, specify the Git commit identifier for the 1.2 release to ensure the reproducibility of the builds. 